### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#DDHTimerControl
+# DDHTimerControl
 
 A control to input minutes or seconds.
 
 ![](https://raw.githubusercontent.com/dasdom/DDHTimerControl/master/what.gif)
 
 
-##Usage
+## Usage
 
     DDHTimerControl *timerControl = [DDHTimerControl timerControlWithType:DDHTimerTypeEqualElements];
     timerControl.translatesAutoresizingMaskIntoConstraints = NO;
@@ -42,11 +42,11 @@ Currently there are three types supported:
     };
 
     
-##Requirements
+## Requirements
 
 ARC and iOS7
 
-##Installation
+## Installation
 
 ### Using CocoaPods
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
